### PR TITLE
Fix blog 404 issue - remove conflicting redirect rule

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,12 +2,6 @@
   publish = "_site"
   command = "bundle install && npm install && npm run build"
 
-# Redirect rules for SPA routing (if needed)
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
-
 # Headers for better caching
 [[headers]]
   for = "/assets/*"


### PR DESCRIPTION
The wildcard redirect was catching /blog/ routes and redirecting them to /index.html, causing the custom 404 page to appear. Removed the SPA redirect rule since we're serving static HTML files.